### PR TITLE
Use env SECRET_KEY and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ python main.py{
 }
 
 Authorization: <token>
+```
+
+Before running `main.py`, set the `SECRET_KEY` environment variable:
+
+```bash
+export SECRET_KEY="your-secret-key"
+python main.py
+```

--- a/main.py
+++ b/main.py
@@ -1,9 +1,13 @@
 from flask import Flask, request, jsonify
 import jwt
 import datetime
+import os
 
 app = Flask(__name__)
-app.config['SECRET_KEY'] = 'super-secret-key'
+secret_key = os.environ.get('SECRET_KEY')
+if not secret_key:
+    raise RuntimeError("SECRET_KEY environment variable not set")
+app.config['SECRET_KEY'] = secret_key
 
 @app.route('/login', methods=['POST'])
 def login():


### PR DESCRIPTION
## Summary
- load `SECRET_KEY` from environment and fail fast if missing
- document `SECRET_KEY` setup in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68409331f0ec832b82ad34bfd6cef725