### PR TITLE
Enable configurable Flask debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ export SECRET_KEY="your-secret-key"
 export USERNAME="admin"            # or use CREDENTIALS_FILE
 export PASSWORD_HASH="<hashed password>"
 # Optional: export CREDENTIALS_FILE=/path/to/credentials.json
+# Optional: export FLASK_DEBUG=1   # enable Flask debug mode
 ```
 
 The credentials file (if used) should contain JSON with `username` and `password_hash` fields.
@@ -24,6 +25,8 @@ If a plain `password` field is provided, it will be hashed on startup.
 2. Run the application:
 
 ```bash
+# Optional: enable debug output
+export FLASK_DEBUG=1
 python main.py
 ```
 

--- a/main.py
+++ b/main.py
@@ -74,5 +74,7 @@ def protected():
         return jsonify({'message': 'Invalid token'}), 401
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_env = os.environ.get('FLASK_DEBUG', '0')
+    debug_mode = debug_env.lower() in ('1', 'true', 't', 'yes')
+    app.run(debug=debug_mode)
 


### PR DESCRIPTION
## Summary
- add environment variable `FLASK_DEBUG` to toggle debug mode
- mention `FLASK_DEBUG` usage in README

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6840969ddd6c832b8e9a26a11d3ec006