### PR TITLE
Set admin role for login JWT payload

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ def login():
     if username == STORED_USERNAME and check_password_hash(STORED_PASSWORD_HASH, password):
         token = jwt.encode({
             'user': username,
-            'role': 'user',
+            'role': 'admin',
             'exp': datetime.datetime.utcnow() + datetime.timedelta(minutes=30)
         }, app.config['SECRET_KEY'], algorithm='HS256')
         return jsonify({'token': token})


### PR DESCRIPTION
## Summary
- update JWT generation to assign the `admin` role

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68409cd1d5f4832ba8ba6a8668e0d008