### PR TITLE
Add Flask auth endpoint tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,32 @@
+import os
+import pytest
+from werkzeug.security import generate_password_hash
+
+# Setup environment variables before importing the app
+os.environ.setdefault('SECRET_KEY', 'test-secret')
+os.environ.setdefault('USERNAME', 'testuser')
+os.environ.setdefault('PASSWORD', 'testpass')
+
+from main import app
+
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        yield client
+
+def test_login_returns_token(client):
+    resp = client.post('/login', json={'username': 'testuser', 'password': 'testpass'})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'token' in data and data['token']
+
+def test_protected_no_token(client):
+    resp = client.get('/protected')
+    assert resp.status_code == 401
+
+def test_protected_with_valid_token(client):
+    login_resp = client.post('/login', json={'username': 'testuser', 'password': 'testpass'})
+    token = login_resp.get_json()['token']
+    resp = client.get('/protected', headers={'Authorization': f'Bearer {token}'})
+    assert resp.status_code == 200
+    assert resp.get_json().get('message') == 'Access granted'


### PR DESCRIPTION
## Summary
- add pytest tests for login and protected routes

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68409e19b9b4832b999108e5e89ffc08