### PR TITLE
Fix README example for /protected

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,11 @@ Use the token to call a protected endpoint:
 curl http://localhost:5000/protected \
   -H "Authorization: Bearer $TOKEN"   # header will be: Authorization: Bearer <token>
 ```
+
+Example raw HTTP request:
+
+```http
+GET /protected HTTP/1.1
+Host: localhost:5000
+Authorization: Bearer <token>
+```


### PR DESCRIPTION
## Summary
- show the HTTP request format for calling `/protected`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_68409ecaaf64832b9d54949659772b15