### PR TITLE
Remove unused import in tests

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-from werkzeug.security import generate_password_hash
 
 # Setup environment variables before importing the app
 os.environ.setdefault('SECRET_KEY', 'test-secret')


### PR DESCRIPTION
## Summary
- remove unused werkzeug import from tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'main' due to missing Flask dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6840a4cce32c832b98dc0d98e8b85638