### PR TITLE
Fix invalid role handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,10 +46,12 @@ def login():
     data = request.get_json() or {}
     username = data.get('username')
     password = data.get('password')
-    # Use provided role if valid; otherwise fall back to the default "admin" role
-    role = data.get('role', 'admin')
-    if role not in ALLOWED_ROLES:
+    # Validate role if provided
+    role = data.get('role')
+    if role is None:
         role = 'admin'
+    elif role not in ALLOWED_ROLES:
+        return jsonify({'message': 'Invalid role'}), 400
 
     if username == STORED_USERNAME and check_password_hash(STORED_PASSWORD_HASH, password):
         token = jwt.encode({

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,3 +29,7 @@ def test_protected_with_valid_token(client):
     resp = client.get('/protected', headers={'Authorization': f'Bearer {token}'})
     assert resp.status_code == 200
     assert resp.get_json().get('message') == 'Access granted'
+
+def test_login_invalid_role(client):
+    resp = client.post('/login', json={'username': 'testuser', 'password': 'testpass', 'role': 'invalid'})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- return `400 Bad Request` when the supplied role is invalid
- test that an invalid role triggers the new error response

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840a6076e8c832bb6767ef781b34732