### PR TITLE
Fix README usage snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ export PASSWORD_HASH="<hashed password>"
 The credentials file (if used) should contain JSON with `username` and `password_hash` fields.
 If a plain `password` field is provided, it will be hashed on startup.
 
+Example credentials file:
+
+```json
+{
+  "username": "admin",
+  "password_hash": "<hashed password>"
+}
+```
+
 3. Run the application:
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify credentials JSON example in Usage section
- ensure `python main.py` line has no stray characters

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6840a00d3b40832baada903fafe961df