### PR TITLE
Fix README role description

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This example demonstrates a minimal REST API using Flask and JWT-based authentic
 ## Features
 
 - `/login`: Accepts a username and password, returning a short-lived JWT token.
-- `/protected`: Example endpoint that validates a JWT token and requires the `admin` role.
+- `/protected`: Example endpoint that validates a JWT token and requires either the `admin` or `user` role.
 
 ## Development and Testing
 


### PR DESCRIPTION
## Summary
- correct role info for /protected endpoint

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6840b190b5d4832ba0234849d8e30670