### PR TITLE
Fix README duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,35 +7,8 @@ This example demonstrates a minimal REST API using Flask and JWT-based authentic
 - `/login`: Accepts a username and password, returning a short-lived JWT token.
 - `/protected`: Example endpoint that validates a JWT token and requires either the `admin` or `user` role.
 
-## Development and Testing
+## Setup
 
-Install the development dependencies and run the tests with `pytest`:
-
-```bash
-pip install -r requirements.txt
-pytest
-```
-
-## Usage
-
-1. Start the server:
-```bash
-python main.py
-```
-
-2. Obtain a token:
-```bash
-curl -X POST http://127.0.0.1:5000/login -H "Content-Type: application/json" -d '{
-  "username": "admin",
-  "password": "123"
-}'
-```
-
-3. Access the protected route with the token:
-```bash
-curl http://127.0.0.1:5000/protected -H "Authorization: Bearer <token>"
-```
-=======
 1. Install dependencies:
 
 ```bash
@@ -58,8 +31,7 @@ export PASSWORD_HASH="<hashed password>"
 # Optional: export FLASK_DEBUG=1   # enable Flask debug mode
 ```
 
-The credentials file (if used) should contain JSON with `username` and `password_hash` fields.
-If a plain `password` field is provided, it will be hashed on startup.
+If you use a credentials file, it should contain JSON with `username` and `password_hash` fields. If a plain `password` field is provided, it will be hashed on startup.
 
 Example credentials file:
 
@@ -68,26 +40,38 @@ Example credentials file:
   "username": "admin",
   "password_hash": "<hashed password>"
 }
+```
+
+## Usage
+
+1. Start the server:
 
 ```bash
-# Optional: enable debug output
-export FLASK_DEBUG=1
 python main.py
 ```
 
-Send a login request and store the returned token:
+2. Obtain a token:
+
+```bash
+curl -X POST http://127.0.0.1:5000/login -H "Content-Type: application/json" -d '{
+  "username": "admin",
+  "password": "your-password"
+}'
+```
+
+3. Access the protected route with the token:
+
+```bash
+curl http://127.0.0.1:5000/protected -H "Authorization: Bearer <token>"
+```
+
+Alternatively, store the token in a variable:
 
 ```bash
 TOKEN=$(curl -s -X POST http://localhost:5000/login \
   -H "Content-Type: application/json" \
   -d '{"username": "admin", "password": "your-password"}' | jq -r '.token')
-```
-
-Use the token to call a protected endpoint:
-
-```bash
-curl http://localhost:5000/protected \
-  -H "Authorization: Bearer $TOKEN"   # header will be: Authorization: Bearer <token>
+curl http://localhost:5000/protected -H "Authorization: Bearer $TOKEN"
 ```
 
 Example raw HTTP request:
@@ -101,4 +85,3 @@ Authorization: Bearer <token>
 ## License
 
 This project is licensed under the terms of the [MIT License](LICENSE).
-


### PR DESCRIPTION
## Summary
- clean up README usage and setup sections

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6840b4c6a31c832b9fb1c1842f9331a2