### PR TITLE
Handle missing login fields

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,9 +84,16 @@ def register():
 
 @app.route('/login', methods=['POST'])
 def login():
+    if not request.is_json:
+        return jsonify({'message': 'Invalid or missing JSON payload'}), 400
+
     data = request.get_json() or {}
     username = data.get('username')
     password = data.get('password')
+
+    if not username or not password:
+        return jsonify({'message': 'Username and password required'}), 400
+
     user = USERS.get(username)
     # Ignore any role provided by the request and use the stored role for the user
     if user and check_password_hash(user['password_hash'], password):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -31,6 +31,22 @@ def test_login_invalid_credentials(client):
     assert resp.get_json()['message'] == 'Invalid credentials'
 
 
+def test_login_missing_fields(client):
+    resp = client.post('/login', json={'username': 'admin'})
+    assert resp.status_code == 400
+    assert resp.get_json()['message'] == 'Username and password required'
+
+    resp = client.post('/login', json={'password': 'password'})
+    assert resp.status_code == 400
+    assert resp.get_json()['message'] == 'Username and password required'
+
+
+def test_login_non_json_payload(client):
+    resp = client.post('/login', data='not json', content_type='text/plain')
+    assert resp.status_code == 400
+    assert resp.get_json()['message'] == 'Invalid or missing JSON payload'
+
+
 def test_token_expired(client):
     expired_token = jwt.encode({
         'user': 'admin',


### PR DESCRIPTION
## Summary
- validate JSON payload in `login`
- ensure username and password are provided
- add tests for missing fields and non-json payloads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6840bc2ae224832bbd1ae9db331e3ec5