### PR TITLE
Handle invalid JSON in register

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,7 +61,13 @@ USERS = {
 @app.route('/register', methods=['POST'])
 def register():
     """Register a new user with a username, password and optional role."""
-    data = request.get_json() or {}
+    if not request.is_json:
+        return jsonify({'message': 'Invalid JSON payload'}), 400
+
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({'message': 'Invalid JSON payload'}), 400
+
     username = data.get('username')
     password = data.get('password')
     role = data.get('role', 'user')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,3 +54,21 @@ def test_register_and_login_new_user(client):
 def test_register_existing_user(client):
     resp = client.post('/register', json={'username': 'testuser', 'password': 'another'})
     assert resp.status_code == 400
+
+
+def test_register_invalid_json(client):
+    resp = client.post('/register', data='not json', content_type='text/plain')
+    assert resp.status_code == 400
+    assert resp.get_json()['message'] == 'Invalid JSON payload'
+
+
+def test_register_missing_username(client):
+    resp = client.post('/register', json={'password': 'somepass'})
+    assert resp.status_code == 400
+    assert resp.get_json()['message'] == 'Username and password required'
+
+
+def test_register_missing_password(client):
+    resp = client.post('/register', json={'username': 'someuser'})
+    assert resp.status_code == 400
+    assert resp.get_json()['message'] == 'Username and password required'


### PR DESCRIPTION
## Summary
- validate JSON payload in `/register`
- extend API tests for invalid or missing registration data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6840bd40f374832bb97835284a99d09a