### PR TITLE
Pin Python dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-Flask
-Werkzeug
-PyJWT
-pytest
+# Specify ranges to ensure reproducible installs
+Flask>=2.0,<3.0
+Werkzeug>=2.0,<3.0
+PyJWT>=2.7,<3
+pytest>=6.0,<9


### PR DESCRIPTION
## Summary
- pin dependencies in `requirements.txt` for reproducible installs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask<3.0,>=2.0)*

------
https://chatgpt.com/codex/tasks/task_e_6840c0faae54832b86566a6277402f6e