### PR TITLE
Add invalid role registration test

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,3 +72,9 @@ def test_register_missing_password(client):
     resp = client.post('/register', json={'username': 'someuser'})
     assert resp.status_code == 400
     assert resp.get_json()['message'] == 'Username and password required'
+
+
+def test_register_invalid_role(client):
+    resp = client.post('/register', json={'username': 'u', 'password': 'p', 'role': 'guest'})
+    assert resp.status_code == 400
+    assert 'Invalid role' in resp.get_json().get('message', '')


### PR DESCRIPTION
## Summary
- add coverage for invalid roles when registering

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_6840c2920258832b93d656d088e179da