### PR TITLE
Add requirements-dev.txt for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ This example demonstrates a minimal REST API using Flask and JWT-based authentic
 pip install -r requirements.txt
 ```
 
+For development or running the tests install the additional dependencies:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
 2. (Optional) run the tests:
 
 ```bash

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest>=6.0,<9
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@
 Flask>=2.0,<3.0
 Werkzeug>=2.0,<3.0
 PyJWT>=2.7,<3
-pytest>=6.0,<9


### PR DESCRIPTION
## Summary
- split pytest into new `requirements-dev.txt`
- document dev install in README

## Testing
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*